### PR TITLE
Remove Invite Link

### DIFF
--- a/src/syntax.grammar
+++ b/src/syntax.grammar
@@ -1703,7 +1703,7 @@ fixedSizeBufferDeclarator { identifier delim<'[' expr ']'> }
 
 /*globalAttrs { globalAttrSection+ }
 
-globalAttrSection {https://replit.com/join/eutvsrecsr-theangryepicbanana
+globalAttrSection {
 	'[' globalAttrTargetSpecifier csep1<attr> ','? ']'
 }
 


### PR DESCRIPTION
Seems like taeb accidentally left an invite link. Remove the invite url on his Repl, this PR removes it from the grammar.

https://replit.slack.com/archives/C01MF4G29UH/p1690269335633449